### PR TITLE
Improve redirects

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,4 +1,8 @@
-maas/en: /maas/en/
-maas/?(?!.*en).*: /maas/en/
-core/en: /core/en/
-core/?(?!.*en).*: /core/en/
+# Redirect project section roots to English language
+(?P<project>maas|core)/?: /{project}/en/
+
+# Add slash to language folders, and remove "index"
+(?P<project>maas|core)/(?P<language>[^/]+)(/index)?: /{project}/{language}/
+
+# Remove trailing slash or .html from document URLs
+(?P<project>maas|core)/(?P<language>[^/]+)/(?P<document>.*)(/|.html): /{project}/{language}/{document}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ django-static-root-finder==0.1
 django-asset-server-url==0.1
 django-template-finder-view==0.2
 django-unslashed==0.3.0
-django-yaml-redirects==0.4
+django-yaml-redirects==0.5.4


### PR DESCRIPTION
- Make it language agnostic - all redirects should work for any language folder
- Remove trailing slashes, html extensions and "index" pages
## QA

Run the site and check the following redirects happen:
- `/core` -> `/core/en/`
- `/core/en` -> `/core/en/`
- `/core/en/index` -> `/core/en/`
- `/core/en/guides/build-device/image-building/` -> `/core/en/guides/build-device/image-building`
- `/core/en/guides/build-device/image-building.html` -> `/core/en/guides/build-device/image-building`
