### PR TITLE
Add tag manager code

### DIFF
--- a/rebuild-docs
+++ b/rebuild-docs
@@ -13,6 +13,7 @@ documentation-builder --base-directory ${maas_dir}  \
                       --output-path templates/maas  \
                       --output-media-path static/media/maas  \
                       --media-url '/static/media/maas'  \
+                      --tag-manager-code 'GTM-K92JCQ'  \
                       --no-link-extensions \
                       --force
 
@@ -21,6 +22,7 @@ documentation-builder --base-directory ${core_dir}  \
                       --output-path templates/core  \
                       --output-media-path static/media/core  \
                       --media-url '/static/media/core'  \
+                      --tag-manager-code 'GTM-K92JCQ'  \
                       --no-link-extensions \
                       --force
 

--- a/templates/includes/layout.html
+++ b/templates/includes/layout.html
@@ -1,12 +1,25 @@
 <!doctype html>
 <html lang="en">
     <head>
+        <!-- Google Tag Manager -->
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
+        <!-- End Google Tag Manager -->
+
         <meta charset="UTF-8" />
         <title>Ubuntu documentation</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="/static/css/homepage.css" />
     </head>
     <body class="theme">
+        <!-- Google Tag Manager (noscript) -->
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-K92JCQ"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+        <!-- End Google Tag Manager (noscript) -->
+
         <main id="main-content">
                 {% block content %}{% endblock content %}
         </main>


### PR DESCRIPTION
to both index.html and the built docs pages

fixes #10.

QA
---

``` bash
snap refresh documentation-builder --channel candidate
./rebuild-docs
./run
```

Check the homepage and all the built docs have tag manager snippet code.