### PR TITLE
Make sure /maas/2.1/ redirects to /maas/2.1/en/

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -4,7 +4,7 @@ phone/?: /phone/en/
 maas(/|/en/?|/2.1/?)?: /maas/2.1/en/
 
 # Add slash to language and version folders, and remove "index"
-(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+)(/index)?: /{project}/{version}/en/
+(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+)(/|/index)?: /{project}/{version}/en/
 (?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+/)?(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{version}{language}/
 
 # Remove trailing slash or .html from document URLs


### PR DESCRIPTION
QA
--

```
./run
```

<http://127.0.0.1:8007/maas/2.1/> -> check it goes to <http://127.0.0.1:8007/maas/2.1/en/>.