### PR TITLE
Remove redirect loop and update redirects

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -4,8 +4,9 @@ phone/?: /phone/en/
 maas(/|/en/?|/2.1/?)?: /maas/2.1/en/
 
 # Add slash to language and version folders, and remove "index"
-(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+)(/|/index)?: /{project}/{version}/en/
-(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+/)?(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{version}{language}/
+(?P<project>maas|core|phone)/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{language}/
+(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+)(/index)?: /{project}/{version}/en/
+(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+)/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{version}/{language}/
 
 # Remove trailing slash or .html from document URLs
-(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}
+(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.+)(/|/index|.html): /{project}/{version}{language}/{document}


### PR DESCRIPTION
Stop /core/en/ redirect looping.
Make sure /maas/ links correctly point to versioned URL
Make sure to remove trailing /index and .html as required.

These redirects should all work:
- `/core`
- `/core/`
- `/core/en`

Should go to ➡️ `/core/en/`


- `/core/en/test/`
- `/core/en/test/index`
- `/core/en/test.html`

Should go to ➡️ `/core/en/test`


- `/maas`
- `/maas/`
- `/maas/2.1`
- `/maas/2.1/`
- `/maas/2.1/en`
- `/maas/en`
- `/maas/en/`

Should go to ➡️ `/maas/2.1/en/`


- `/maas/2.1/en/test/`
- `/maas/2.1/en/test/index`
- `/maas/2.1/en/test.html`

Should go to ➡️ `/maas/2.1/en/test`