### PR TITLE
Allow /index at end of paths

### DIFF
--- a/rebuild-docs
+++ b/rebuild-docs
@@ -7,9 +7,9 @@ phone_dir=phone-docs
 core_dir=ubuntu-core-docs
 snapcraft_dir=snapcraft-docs
 
-git-force-clone https://github.com/canonicalltd/maas-docs.git ${maas_dir} || true
-git-force-clone https://github.com/canonicalltd/ubuntu-core-docs.git ${core_dir} || true
-git-force-clone https://github.com/ubuntudesign/phone-docs.git ${phone_dir} || true
+rm -rf ${maas_dir} && git clone https://github.com/canonicalltd/maas-docs.git ${maas_dir} || true
+rm -rf ${core_dir} && git clone https://github.com/canonicalltd/ubuntu-core-docs.git ${core_dir} || true
+rm -rf ${phone_dir} && git clone https://github.com/ubuntudesign/phone-docs.git ${phone_dir} || true
 #git clone https://github.com/canonicalltd/snapcraft-docs.git ${snapcraft_dir}
 
 documentation-builder --base-directory ${maas_dir}  \

--- a/redirects.yaml
+++ b/redirects.yaml
@@ -9,8 +9,9 @@ maas(/|/en/?|/2.1/?)?: /maas/2.1/en/
 (?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+)/(?P<language>[a-zA-Z]{2})(/index)?: /{project}/{version}/{language}/
 
 # Remove trailing slash or .html from document URLs
-(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.+)(/|/index|.html): /{project}/{version}{language}/{document}
+(?P<project>maas|core|phone)/(?P<version>[a-zA-Z0-9-._]+/)?(?P<language>[a-zA-Z]{2})/(?P<document>.*)(/|.html): /{project}/{version}{language}/{document}
 
 # Pages redirects:
 # On 12/01/2017
 core/en/guides/build-device/assertions: /core/en/reference/assertions
+


### PR DESCRIPTION
QA
--

``` bash
./rebuild-docs
./run
```

Go to <http://127.0.0.1:8007/core/en/reference/interfaces/index> and click around the documentation bit, check all links still work.