### PR TITLE
Implement search view with ubuntudesign.gsa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ django-asset-server-url==0.1
 django-template-finder-view==0.2
 django-unslashed==0.3.0
 django-yaml-redirects==0.5.4
+ubuntudesign.gsa==1.0.0

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,85 @@
+<!doctype html>
+
+<html>
+  <head>
+  </head>
+
+  <body>
+    <h1>Search this site</h1>
+
+    <form action="/search" class="search">
+      <label for="search-input" class="search__label">Search</label>
+      <input name="q" id="search-input" type="search" value="{{ query }}" placeholder="e.g. juju" class="search__field" />
+      <button class="search__submit" type="submit">
+        <img class="search__image" src="{{ ASSET_SERVER_URL }}19750a6d-search-black.svg" alt="search" />
+      </button>
+    </form>
+
+    {% if query %}
+      {% if error %}
+        <label for="search-input" role="error" class="error-notification">
+          Failed to retrieve search results ({{ error }}). If you have time, please <a href="https://github.com/ubuntudesign/docs.ubuntu.com/issues/new">file a bug</a>.
+        </label>
+      {% else %}
+        {% if results.items %}
+          <h4>{{ results.total }} results for "{{ query }}"</h4>
+
+          <section id="search-results" class="no-margin-bottom list list-spaced">
+            <p class="result-line results-top">Results {{ results.start }} to {{ results.end }}</p>
+
+            {% for item in results.items %}
+              <article class="search-result twelve-col">
+                <h4>
+                  <a href="{{ item.url }}" class="title-main">{{ item.title | safe }}</a>
+                  <small class="result-url">{{ item.url }}</small>
+                </h4>
+                <p>{{ item.summary | safe }}</p>
+              </article>
+            {% endfor %}
+
+            <p class="bottom-results-total result-line">Results {{ results.start }} to {{ results.end }} of {{ results.total }}</p>
+          </section>
+
+          {% if results.last_page > 1 %}
+            <nav class="pagination" id="page-nav">
+              {% if results.current_page > 1 %}
+                <ul class="pagination__back">
+                  <li class="pagination__item"><a href="/search?q={{ query }}&limit={{ limit }}&offset=0">&#8249;&#8249; First</a></li>
+                  {% if results.current_page > 2 %}
+                    <li class="pagination__item"><a href="/search?q={{ query }}&limit={{ limit }}&offset={{ results.previous_offset }}">&#8249; Previous</a></li>
+                  {% endif %}
+                </ul>
+              {% endif %}
+
+              {% if results.current_page != results.last_page %}
+                <ul class="pagination__forward">
+                  {% if results.current_page < results.penultimate_page %}
+                    <li class="pagination__item"><a href="/search?q={{ query }}&limit={{ limit }}&offset={{ results.next_offset }}">Next &#8250;</a></li>
+                  {% endif %}
+                  <li class="pagination__item"><a href="/search?q={{ query }}&limit={{ limit }}&offset={{ results.last_page_offset }}">Last &#8250;&#8250;</a></li>
+                </ul>
+              {% endif %}
+            </nav>
+          {% endif %}
+        {% else %}
+          <h2>Sorry we couldn't find "{{ query }}"</h2>
+
+          <h3>Why not try widening your search? You can do this by:</h3>
+
+          <ul>
+            <li>Adding alternative words or phrases</li>
+            <li>Using individual words instead of phrases</li>
+            <li>Trying a different spelling</li>
+          </ul>
+
+          <h2>Still no luck?</h2>
+
+          <ul>
+            <li><a href="/">Visit the homepage</a></li>
+            <li><a href="https://github.com/ubuntudesign/docs.ubuntu.com/issues/new">Report an issue with the site</a></li>
+          </ul>
+        {% endif %} {# results.items #}
+      {% endif %}
+    {% endif %} {# query #}
+  </body>
+</html>

--- a/webapp/settings.py
+++ b/webapp/settings.py
@@ -38,6 +38,15 @@ REMOVE_SLASH = True
 STATIC_ROOT = "static"
 STATIC_URL = '/static/'
 
+# Use the IP address for now, as Docker doesn't use the
+# VPN DNS server
+# @TODO: Once Docker sorts this out, go back to using butlerov
+# https://github.com/docker/docker/issues/23910
+
+# SEARCH_SERVER_URL = 'http://butlerov.internal/search'
+SEARCH_SERVER_URL = 'http://10.22.112.8/search'
+SEARCH_DOMAINS = ['docs.ubuntu.com']
+
 WHITENOISE_ALLOW_ALL_ORIGINS = False
 
 ASSET_SERVER_URL = 'https://assets.ubuntu.com/v1/'

--- a/webapp/urls.py
+++ b/webapp/urls.py
@@ -2,6 +2,7 @@
 from django.conf.urls import url
 from django_yaml_redirects import load_redirects
 from django_template_finder_view import TemplateFinder
+from ubuntudesign.gsa.views import SearchView
 
 # Local
 from webapp.views import custom_404, custom_500
@@ -10,7 +11,10 @@ from webapp.views import custom_404, custom_500
 urlpatterns = load_redirects()
 
 # Try to find templates
-urlpatterns.append(url(r'^(?P<template>.*)/?$', TemplateFinder.as_view()))
+urlpatterns += [
+    url(r'^search/?$', SearchView.as_view(template_name='search.html')),
+    url(r'^(?P<template>.*)/?$', TemplateFinder.as_view())
+]
 
 # Error handlers
 handler404 = custom_404


### PR DESCRIPTION
Get search working at `/search`.

At present this is completely unstyled. The style will come later.

QA
---

*Connect to the VPN* and run the site natively:

``` bash
virtualenv env
env/bin/pip install -r requirements.txt
env/bin/python manage.py runserver 0.0.0.0:8007
```

Now visit <http://127.0.0.1:8007/search>. Check it functions properly (although it will look horrible).