### PR TITLE
Fix images in 1.9 documentation

### DIFF
--- a/templates/maas/1.9/en/cluster-configuration.html
+++ b/templates/maas/1.9/en/cluster-configuration.html
@@ -101,10 +101,10 @@ below).  Any other cluster controllers you set up will show up in the user
 interface as &#8220;pending,&#8221; until you manually accept them into the MAAS.</p>
 <p>To accept a cluster controller, visit the &#8220;pending clusters&#8221; section of the
 Clusters page:</p>
-<img alt="/static/maas-1.9/cluster-accept.png" src="_images/cluster-accept.png" />
+<img alt="/static/maas-1.9/cluster-accept.png" src="/static/maas-1.9/cluster-accept.png" />
 <p>You can either click on &#8220;Accept all&#8221; or click on the edit icon to edit
 the cluster.  After clicking on the edit icon, you will see this page:</p>
-<img alt="/static/maas-1.9/cluster-edit.png" src="_images/cluster-edit.png" />
+<img alt="/static/maas-1.9/cluster-edit.png" src="/static/maas-1.9/cluster-edit.png" />
 <p>Here you can change the cluster&#8217;s name as it appears in the UI, its DNS
 zone, and its status.  Accepting the cluster changes its status from
 &#8220;pending&#8221; to &#8220;accepted.&#8221;</p>
@@ -127,7 +127,7 @@ the MAAS user interface.</p>
 <p>As an example, we will configure the cluster controller to manage a network
 on interface <code class="docutils literal"><span class="pre">eth0</span></code>.  Click on the edit icon for the cluster interface on
 network interface <code class="docutils literal"><span class="pre">eth0</span></code>, which takes us to this page:</p>
-<img alt="/static/maas-1.9/cluster-interface-edit.png" src="_images/cluster-interface-edit.png" />
+<img alt="/static/maas-1.9/cluster-interface-edit.png" src="/static/maas-1.9/cluster-interface-edit.png" />
 <p>Here you can select to what extent you want the cluster controller to manage
 the network:</p>
 <ol class="arabic simple">

--- a/templates/maas/1.9/en/configure.html
+++ b/templates/maas/1.9/en/configure.html
@@ -131,7 +131,7 @@ wish to install on an individual node. When either adding a node
 manually, or on the node page when the node has been automatically
 discovered but before it is accepted, there is a drop down menu to select
 the version of Ubuntu you wish to install.</p>
-<img alt="/static/maas-1.9/series.png" src="_images/series.png" />
+<img alt="/static/maas-1.9/series.png" src="/static/maas-1.9/series.png" />
 <p>The menu will always list all the currently available series according
 to which boot images are available.</p>
 </div>
@@ -242,7 +242,7 @@ want to organise the nodes on a more distributed basis. The standard install of
 the MAAS region controller includes a cluster controller, but it is
 possible to add additional cluster controllers to the configuration, as
 shown in the diagram below:</p>
-<img alt="/static/maas-1.9/orientation_architecture-diagram.png" src="_images/orientation_architecture-diagram.png" />
+<img alt="/static/maas-1.9/orientation_architecture-diagram.png" src="/static/maas-1.9/orientation_architecture-diagram.png" />
 <p>Each cluster controller will need to run on a separate Ubuntu server.
 Installing and configuring the software is straightforward though:</p>
 <div class="highlight-python"><div class="highlight"><pre>$ sudo apt-get install maas-cluster-controller
@@ -262,7 +262,7 @@ configure the software:</p>
 <div class="highlight-python"><div class="highlight"><pre>$ dpkg-reconfigure maas-cluster-controller
 </pre></div>
 </div>
-<img alt="/static/maas-1.9/cluster-config.png" src="_images/cluster-config.png" />
+<img alt="/static/maas-1.9/cluster-config.png" src="/static/maas-1.9/cluster-config.png" />
 <p>The configuration script should then bring up a screen where you can
 enter the IP address of the region controller. Additionally, you will
 need to import the distro image files locally for commissioning:</p>

--- a/templates/maas/1.9/en/hardware-enablement-kernels.html
+++ b/templates/maas/1.9/en/hardware-enablement-kernels.html
@@ -106,7 +106,7 @@ an error.</p>
 the Node&#8217;s page and clicking <code class="docutils literal"><span class="pre">Edit</span> <span class="pre">node</span></code>. Under the Minimum Kernel field, you
 will be able to select any HWE kernels that have been imported onto that node&#8217;s
 cluster controller.</p>
-<img alt="/static/maas-1.9/min_hwe_kernel.png" src="_images/min_hwe_kernel.png" />
+<img alt="/static/maas-1.9/min_hwe_kernel.png" src="/static/maas-1.9/min_hwe_kernel.png" />
 <p>You can also set the hwe_kernel during deployment. MAAS checks that the
 specified kernel is avalible for the release specified before deploying the
 node. You can set the hwe_kernel when deploying by using the command:</p>
@@ -115,7 +115,7 @@ hwe_kernel=hwe-&lt;release letter&gt;
 </pre></div>
 </div>
 <p>Or through the web interface as seen below.</p>
-<img alt="/static/maas-1.9/hwe_kernel.png" src="_images/hwe_kernel.png" />
+<img alt="/static/maas-1.9/hwe_kernel.png" src="/static/maas-1.9/hwe_kernel.png" />
 </div>
 </div>
 

--- a/templates/maas/1.9/en/install.html
+++ b/templates/maas/1.9/en/install.html
@@ -151,7 +151,7 @@ proceed. The exact list will obviously depend on what you already have
 installed on your server, but expect to add about 200MB of files.</p>
 <p>The configuration for the MAAS controller will automatically run and
 pop up this config screen:</p>
-<img alt="/static/maas-1.9/install_cluster-config.png" src="_images/install_cluster-config.png" />
+<img alt="/static/maas-1.9/install_cluster-config.png" src="/static/maas-1.9/install_cluster-config.png" />
 <p>Here you will need to enter the hostname for where the region
 controller can be contacted. In many scenarios, you may be running the
 region controller (i.e. the web and API interface) from a different
@@ -185,7 +185,7 @@ Controller that&#8217;s on the same network as the Cluster Controller:</p>
 <div>$ sudo dpkg-reconfigure maas-cluster-controller</div></blockquote>
 <p>The configuration for the MAAS Cluster Controller will automatically
 run and pop up this config screen:</p>
-<img alt="/static/maas-1.9/install_cluster-config.png" src="_images/install_cluster-config.png" />
+<img alt="/static/maas-1.9/install_cluster-config.png" src="/static/maas-1.9/install_cluster-config.png" />
 <p>Once entered, the MAAS Cluster Controller configuration will request</p>
 </div>
 </div>
@@ -196,54 +196,54 @@ choose the &#8220;Multiple Server install with MAAS&#8221; option from the
 installer and have pretty much everything set up for you.  Boot from
 the Ubuntu Server media and you will be greeted with the usual
 language selection screen:</p>
-<img alt="/static/maas-1.9/install_01.png" src="_images/install_01.png" />
+<img alt="/static/maas-1.9/install_01.png" src="/static/maas-1.9/install_01.png" />
 <p>On the next screen, you will see there is an entry in the menu called
 &#8220;Multiple server install with MAAS&#8221;. Use the cursor keys to select
 this and then press Enter.</p>
-<img alt="/static/maas-1.9/install_02.png" src="_images/install_02.png" />
+<img alt="/static/maas-1.9/install_02.png" src="/static/maas-1.9/install_02.png" />
 <p>The installer then runs through the usual language and keyboard
 options. Make your selections using Tab/Cursor keys/Enter to proceed
 through the install.  The installer will then load various drivers,
 which may take a moment or two.</p>
-<img alt="/static/maas-1.9/install_03.png" src="_images/install_03.png" />
+<img alt="/static/maas-1.9/install_03.png" src="/static/maas-1.9/install_03.png" />
 <p>The next screen asks for the hostname for this server. Choose
 something appropriate for your network.</p>
-<img alt="/static/maas-1.9/install_04.png" src="_images/install_04.png" />
+<img alt="/static/maas-1.9/install_04.png" src="/static/maas-1.9/install_04.png" />
 <p>Finally we get to the MAAS part! Here there are just two options. We
 want to &#8220;Create a new MAAS on this server&#8221; so go ahead and choose that
 one.</p>
-<img alt="/static/maas-1.9/install_05.png" src="_images/install_05.png" />
+<img alt="/static/maas-1.9/install_05.png" src="/static/maas-1.9/install_05.png" />
 <p>The install now continues as usual. Next you will be prompted to enter
 a username. This will be the admin user for the actual server that
 MAAS will be running on (not the same as the MAAS admin user!)</p>
-<img alt="/static/maas-1.9/install_06.png" src="_images/install_06.png" />
+<img alt="/static/maas-1.9/install_06.png" src="/static/maas-1.9/install_06.png" />
 <p>As usual you will have the chance to encrypt your home
 directory. Continue to make selections based on whatever settings suit
 your usage.</p>
-<img alt="/static/maas-1.9/install_07.png" src="_images/install_07.png" />
+<img alt="/static/maas-1.9/install_07.png" src="/static/maas-1.9/install_07.png" />
 <p>After making selections and partitioning storage, the system software
 will start to be installed. This part should only take a few minutes.</p>
-<img alt="/static/maas-1.9/install_09.png" src="_images/install_09.png" />
+<img alt="/static/maas-1.9/install_09.png" src="/static/maas-1.9/install_09.png" />
 <p>Various packages will now be configured, including the package manager
 and update manager. It is important to set these up appropriately so
 you will receive timely updates of the MAAS server software, as well
 as other essential services that may run on this server.</p>
-<img alt="/static/maas-1.9/install_10.png" src="_images/install_10.png" />
+<img alt="/static/maas-1.9/install_10.png" src="/static/maas-1.9/install_10.png" />
 <p>The configuration for MAAS will ask you to configure the host address
 of the server. This should be the IP address you will use to connect
 to the server (you may have additional interfaces e.g. to run node
 subnets)</p>
-<img alt="/static/maas-1.9/install_cluster-config.png" src="_images/install_cluster-config.png" />
+<img alt="/static/maas-1.9/install_cluster-config.png" src="/static/maas-1.9/install_cluster-config.png" />
 <p>The next screen will confirm the web address that will be used to the
 web interface.</p>
-<img alt="/static/maas-1.9/install_controller-config.png" src="_images/install_controller-config.png" />
+<img alt="/static/maas-1.9/install_controller-config.png" src="/static/maas-1.9/install_controller-config.png" />
 <p>After configuring any other packages the installer will finally come
 to and end. At this point you should eject the boot media.</p>
-<img alt="/static/maas-1.9/install_14.png" src="_images/install_14.png" />
+<img alt="/static/maas-1.9/install_14.png" src="/static/maas-1.9/install_14.png" />
 <p>After restarting, you should be able to login to the new server with
 the information you supplied during the install. The MAAS software
 will run automatically.</p>
-<img alt="/static/maas-1.9/install_15.png" src="_images/install_15.png" />
+<img alt="/static/maas-1.9/install_15.png" src="/static/maas-1.9/install_15.png" />
 <p><strong>NOTE:</strong> The maas-dhcp and maas-dns packages should be installed by
 default, but on older releases of MAAS they won&#8217;t be. If you want to
 have MAAS run DHCP and DNS services, you should install these packages.
@@ -264,7 +264,7 @@ Check whether they are installed with:</p>
 If you now use a web browser to connect to the region controller, you
 should see that MAAS is running, but there will also be some errors on
 the screen:</p>
-<img alt="/static/maas-1.9/install_web-init.png" src="_images/install_web-init.png" />
+<img alt="/static/maas-1.9/install_web-init.png" src="/static/maas-1.9/install_web-init.png" />
 <p>The on screen messages will tell you that there are no boot images
 present, and that you can&#8217;t login because there is no admin user.</p>
 <div class="section" id="create-a-superuser-account">
@@ -286,7 +286,7 @@ may wish to create, but you need at least one.</p>
 <p>Looking at the region controller&#8217;s main web page again, you should now see
 a login screen.  Log in using the user name and password which you have just
 created.</p>
-<img alt="/static/maas-1.9/install-login.png" src="_images/install-login.png" />
+<img alt="/static/maas-1.9/install-login.png" src="/static/maas-1.9/install-login.png" />
 </div>
 <div class="section" id="import-the-boot-images">
 <h2>Import the boot images<a class="headerlink" href="install.html#import-the-boot-images" title="Permalink to this headline">¶</a></h2>
@@ -300,7 +300,7 @@ the import: through the web user interface, or through the remote API.</p>
 <p>To do it in the web user interface, go to the Images tab, check the boxes to
 say which images you want to import, and click the &#8220;Import images&#8221; button at
 the bottom of the Ubuntu section.</p>
-<img alt="/static/maas-1.9/import-images.png" src="_images/import-images.png" />
+<img alt="/static/maas-1.9/import-images.png" src="/static/maas-1.9/import-images.png" />
 <p>A message will appear to let you know that the import has started, and after a
 while, the warnings about the lack of boot images will disappear.</p>
 <p>It may take a long time, depending on the speed of your Internet connection for

--- a/templates/maas/1.9/en/kernel-options.html
+++ b/templates/maas/1.9/en/kernel-options.html
@@ -65,7 +65,7 @@ a global basis and a per-node basis.</p>
 <h2>Global kernel options<a class="headerlink" href="kernel-options.html#global-kernel-options" title="Permalink to this headline">¶</a></h2>
 <p>As an admin, click on the gear icon at the top right and scroll down to
 the Global Kernel Parameters section, as shown here:</p>
-<img alt="/static/maas-1.9/global_kernel_opts.png" src="_images/global_kernel_opts.png" />
+<img alt="/static/maas-1.9/global_kernel_opts.png" src="/static/maas-1.9/global_kernel_opts.png" />
 <p>Whatever you set here is sent as-is to all booting nodes.</p>
 </div>
 <div class="section" id="per-node-kernel-options">

--- a/templates/maas/1.9/en/maascli.html
+++ b/templates/maas/1.9/en/maascli.html
@@ -74,9 +74,9 @@ on the region controller, retrieved from the command line.</p>
 <p>To obtain the key from the web user interface, log in and click on your
 user name in the top right corner of the page, and select &#8216;Preferences&#8217; from
 the menu which appears.</p>
-<img alt="/static/maas-1.9/maascli-prefs.png" src="_images/maascli-prefs.png" />
+<img alt="/static/maas-1.9/maascli-prefs.png" src="/static/maas-1.9/maascli-prefs.png" />
 <p>A new page will load...</p>
-<img alt="/static/maas-1.9/maascli-key.png" src="_images/maascli-key.png" />
+<img alt="/static/maas-1.9/maascli-key.png" src="/static/maas-1.9/maascli-key.png" />
 <p>Your MAAS API keys appear at the top of the preferences form.  It&#8217;s easiest to
 just select and copy the key (it&#8217;s quite long!) and then paste it into the
 command line.</p>

--- a/templates/maas/1.9/en/networks.html
+++ b/templates/maas/1.9/en/networks.html
@@ -116,7 +116,7 @@ through the API.  The command-line interface acts a front-end for the API.</p>
 <p>To define a network in the user interface, click on <code class="docutils literal"><span class="pre">Networks</span></code> in the top
 bar.  This will take you to the listing of known networks.  Click the
 <code class="docutils literal"><span class="pre">Add</span> <span class="pre">network</span></code> button to start entering your network&#8217;s information.</p>
-<img alt="/static/maas-1.9/add-network.png" src="_images/add-network.png" />
+<img alt="/static/maas-1.9/add-network.png" src="/static/maas-1.9/add-network.png" />
 <p>Assign each network a short name for easy reference, and optionally, a more
 detailed description.  Fill out the other fields as detailed below.  Click
 <code class="docutils literal"><span class="pre">Add</span> <span class="pre">network</span></code> to bring your network definition into effect.</p>
@@ -160,7 +160,7 @@ under the &#8220;Networks&#8221; section in the top bar.</p>
 <p>On the network add/edit pages, you will see a selection box where you can
 select which network interfaces are connected to that network, as well as the
 nodes to which they belong.</p>
-<img alt="/static/maas-1.9/connect-nodes-to-network.png" src="_images/connect-nodes-to-network.png" />
+<img alt="/static/maas-1.9/connect-nodes-to-network.png" src="/static/maas-1.9/connect-nodes-to-network.png" />
 <p>The box lets you select multiple network interfaces, even if they belong to
 the same node.  Click &#8220;Save network&#8221; to make your changes permanent.</p>
 <p>You can also connect nodes to networks using the

--- a/templates/maas/1.9/en/nodes.html
+++ b/templates/maas/1.9/en/nodes.html
@@ -89,7 +89,7 @@ which <a class="reference internal" href="maascli.html#api-key"><span>you can re
 <p>If you know the MAC address of a node, you can manually enter details
 about the node through the web interface. Click the <code class="docutils literal"><span class="pre">Add</span> <span class="pre">Node</span></code> button
 to be taken to the &#8220;Add Node&#8221; form:</p>
-<img alt="/static/maas-1.9/add-node.png" src="_images/add-node.png" />
+<img alt="/static/maas-1.9/add-node.png" src="/static/maas-1.9/add-node.png" />
 </div>
 <div class="section" id="virtual-machine-nodes">
 <h2>Virtual machine nodes<a class="headerlink" href="nodes.html#virtual-machine-nodes" title="Permalink to this headline">¶</a></h2>
@@ -111,7 +111,7 @@ to avoid failures during deployment.</p>
 <dd>This is a libvirt connection string, such as
 <code class="docutils literal"><span class="pre">qemu+ssh://ubuntu&#64;10.0.0.2/system</span></code> or <code class="docutils literal"><span class="pre">qemu:///system</span></code></dd>
 </dl>
-<img alt="/static/maas-1.9/virsh-config.png" src="_images/virsh-config.png" />
+<img alt="/static/maas-1.9/virsh-config.png" src="/static/maas-1.9/virsh-config.png" />
 <p>If you want to use ssh you&#8217;ll need to generate a ssh key pair for the maas
 user.  By default there is no home directory created for the maas user:</p>
 <div class="highlight-python"><div class="highlight"><pre>$ sudo mkdir /home/maas

--- a/templates/maas/1.9/en/orientation.html
+++ b/templates/maas/1.9/en/orientation.html
@@ -121,7 +121,7 @@ need to organise your nodes into different subnets (e.g. if you have a
 lot of nodes).  If you install the <code class="docutils literal"><span class="pre">maas</span></code> package, it will include both a
 region controller and a cluster controller, and they will be automatically
 set up to work together.</p>
-<img alt="/static/maas-1.9/orientation_architecture-diagram.png" src="_images/orientation_architecture-diagram.png" />
+<img alt="/static/maas-1.9/orientation_architecture-diagram.png" src="/static/maas-1.9/orientation_architecture-diagram.png" />
 </div>
 <div class="section" id="how-maas-is-used">
 <h2>How MAAS is used<a class="headerlink" href="orientation.html#how-maas-is-used" title="Permalink to this headline">¶</a></h2>

--- a/templates/maas/1.9/en/physical-zones.html
+++ b/templates/maas/1.9/en/physical-zones.html
@@ -128,7 +128,7 @@ systems are in located different zones.</p>
 zone in the web user interface, log in as an administrator and browse to the
 &#8220;Zones&#8221; section in the top bar.  This will takes you to the zones listing page.
 At the bottom of the page is a button for creating a new zone:</p>
-<img alt="/static/maas-1.9/add-zone.png" src="_images/add-zone.png" />
+<img alt="/static/maas-1.9/add-zone.png" src="/static/maas-1.9/add-zone.png" />
 <p>Or to do it in the <a class="reference internal" href="api.html#region-controller-api"><span>region-controller API</span></a>, POST
 your zone definition to the <em>&#8220;zones&#8221;</em> endpoint.</p>
 </div>


### PR DESCRIPTION
See how <https://docs.ubuntu.com/maas/1.9/en/maascli> has missing images? This fixes it.

QA
--

``` bash
./run
```

Visit <http://127.0.0.1:8007/maas/1.9/en/maascli>, see that images work.